### PR TITLE
Introduce property based tests for more rigor, plus some examples of failing combinations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ documentation = "http://docs.rs/strength_reduce"
 keywords = ["arithmetic", "strength", "reduction", "division", "modulus"]
 categories = ["algorithms", "data-structures"]
 readme = "README.md"
+
+[dev-dependencies]
+proptest = "0.8.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,14 @@
 //! so test before you use. 
 #![no_std]
 
+#[cfg(test)]
+#[macro_use]
+extern crate proptest;
+
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
 use core::ops::{Div, Rem};
 
 macro_rules! strength_reduced_impl {
@@ -217,6 +225,7 @@ strength_reduced_impl_intermediate_multiplier!(StrengthReducedUsize, usize, u128
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+    use proptest::test_runner::Config;
 
     macro_rules! reduction_test {
         ($test_name:ident, $struct_name:ident, $primitive_type:ident) => (
@@ -252,4 +261,80 @@ mod unit_tests {
     reduction_test!(test_strength_reduced_u32, StrengthReducedU32, u32);
     reduction_test!(test_strength_reduced_u64, StrengthReducedU64, u64);
     reduction_test!(test_strength_reduced_usize, StrengthReducedUsize, usize);
+
+    macro_rules! reduction_proptest {
+        ($test_name:ident, $struct_name:ident, $primitive_type:ident) => (
+            mod $test_name {
+                use super::*;
+                use proptest::sample::select;
+
+                fn assert_div_rem_equivalence(divisor: $primitive_type, numerator: $primitive_type) {
+                    let reduced_divisor = $struct_name::new(divisor);
+                    let expected_div = numerator / divisor;
+                    let expected_rem = numerator % divisor;
+                    let reduced_div = numerator / reduced_divisor;
+                    let reduced_rem = numerator % reduced_divisor;
+                    assert_eq!(expected_div, reduced_div, "Divide failed with numerator: {}, divisor: {}", numerator, divisor);
+                    assert_eq!(expected_rem, reduced_rem, "Modulo failed with numerator: {}, divisor: {}", numerator, divisor);
+                    let (reduced_combined_div, reduced_combined_rem) = $struct_name::div_rem(numerator, reduced_divisor);
+                    assert_eq!(expected_div, reduced_combined_div, "div_rem divide failed with numerator: {}, divisor: {}", numerator, divisor);
+                    assert_eq!(expected_rem, reduced_combined_rem, "div_rem modulo failed with numerator: {}, divisor: {}", numerator, divisor);
+                }
+
+
+
+                proptest! {
+                    #![proptest_config(Config::with_cases(100_000))]
+
+                    #[test]
+                    fn fully_generated_inputs_are_div_rem_equivalent(divisor in 1..core::$primitive_type::MAX, numerator in 0..core::$primitive_type::MAX) {
+                        assert_div_rem_equivalence(divisor, numerator);
+                    }
+
+                    #[test]
+                    fn generated_divisors_with_edge_case_numerators_are_div_rem_equivalent(
+                            divisor in 1..core::$primitive_type::MAX,
+                            numerator in select(vec![0 as $primitive_type, 1 as $primitive_type, core::$primitive_type::MAX - 1, core::$primitive_type::MAX])) {
+                        assert_div_rem_equivalence(divisor, numerator);
+                    }
+
+                    #[test]
+                    fn generated_numerators_with_edge_case_divisors_are_div_rem_equivalent(
+                            divisor in select(vec![1 as $primitive_type, 2 as $primitive_type, core::$primitive_type::MAX - 1, core::$primitive_type::MAX]),
+                            numerator in 0..core::$primitive_type::MAX) {
+                        assert_div_rem_equivalence(divisor, numerator);
+                    }
+                }
+            }
+        )
+    }
+
+    reduction_proptest!(strength_reduced_u8, StrengthReducedU8, u8);
+    reduction_proptest!(strength_reduced_u16, StrengthReducedU16, u16);
+    reduction_proptest!(strength_reduced_u32, StrengthReducedU32, u32);
+    reduction_proptest!(strength_reduced_u64, StrengthReducedU64, u64);
+    reduction_proptest!(strength_reduced_usize, StrengthReducedUsize, usize);
+
+    macro_rules! reduction_spot_test {
+        ($test_name:ident, $struct_name:ident, $divisor:expr, $numerator:expr) => (
+            #[test]
+            fn $test_name() {
+                let divisor = $divisor;
+                let numerator = $numerator;
+                let reduced_divisor = $struct_name::new(divisor);
+                let expected_div = numerator / divisor;
+                let expected_rem = numerator % divisor;
+                let reduced_div = numerator / reduced_divisor;
+                let reduced_rem = numerator % reduced_divisor;
+                let (reduced_combined_div, reduced_combined_rem) = $struct_name::div_rem(numerator, reduced_divisor);
+                assert_eq!(expected_div, reduced_div, "Divide failed with numerator: {}, divisor: {}", numerator, divisor);
+                assert_eq!(expected_rem, reduced_rem, "Modulo failed with numerator: {}, divisor: {}", numerator, divisor);
+                assert_eq!(expected_div, reduced_combined_div, "div_rem divide failed with numerator: {}, divisor: {}", numerator, divisor);
+                assert_eq!(expected_rem, reduced_combined_rem, "div_rem modulo failed with numerator: {}, divisor: {}", numerator, divisor);
+            }
+        )
+    }
+
+    reduction_spot_test!(reduced_u8_spot_check_found_failure_case, StrengthReducedU8, 39, 233);
+    reduction_spot_test!(reduced_u16_spot_check_found_failure_case, StrengthReducedU16, 3827, 49750);
 }


### PR DESCRIPTION
This PR is intended to broaden the tested input for this library through the use of property based testing.

So far these test runs have exposed some failing input combinations, a few of which I've included as short term spot-unit-tests for regression comparison.

There's a bit more code replication than I would prefer in the correctness assertion logic, but I haven't had time to introduce sufficient macro or private-trait effort to DRY things up fully. Hopefully it's tolerable for the time being as correctness is improved.