### PR TITLE
Add assignment div/rem operators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ extern crate num_bigint;
 #[cfg(test)]
 extern crate rand;
 
-use core::ops::{Div, Rem};
+use core::ops::{Div, DivAssign, Rem, RemAssign};
 
 mod long_division;
 mod long_multiplication;
@@ -474,6 +474,32 @@ strength_reduced_u16!(StrengthReducedUsize, usize);
 strength_reduced_u32!(StrengthReducedUsize, usize);
 #[cfg(target_pointer_width = "64")]
 strength_reduced_u64!(StrengthReducedUsize, usize);
+
+// Implement assign ops via the non-assigning versions
+macro_rules! impl_assign_ops {
+    ($for:ty, $reduced:ty) => {
+        impl DivAssign<$reduced> for $for {
+            #[inline]
+            fn div_assign(&mut self, rhs: $reduced) {
+                *self = *self / rhs
+            }
+        }
+
+        impl RemAssign<$reduced> for $for {
+            #[inline]
+            fn rem_assign(&mut self, rhs: $reduced) {
+                *self = *self % rhs
+            }
+        }
+    };
+}
+
+impl_assign_ops!(u8, StrengthReducedU8);
+impl_assign_ops!(u16, StrengthReducedU16);
+impl_assign_ops!(u32, StrengthReducedU32);
+impl_assign_ops!(u64, StrengthReducedU64);
+impl_assign_ops!(u128, StrengthReducedU128);
+impl_assign_ops!(usize, StrengthReducedUsize);
 
 #[cfg(test)]
 mod unit_tests {

--- a/tests/test_reduced_unsigned.rs
+++ b/tests/test_reduced_unsigned.rs
@@ -23,6 +23,12 @@ macro_rules! reduction_proptest {
                 let (reduced_combined_div, reduced_combined_rem) = $struct_name::div_rem(numerator, reduced_divisor);
                 assert_eq!(expected_div, reduced_combined_div, "div_rem divide failed with numerator: {}, divisor: {}", numerator, divisor);
                 assert_eq!(expected_rem, reduced_combined_rem, "div_rem modulo failed with numerator: {}, divisor: {}", numerator, divisor);
+                let mut assign_div = numerator;
+                assign_div /= divisor;
+                let mut assign_rem = numerator;
+                assign_rem %= divisor;
+                assert_eq!(expected_div, assign_div, "Divide assign failed with numerator: {}, divisor: {}", numerator, divisor);
+                assert_eq!(expected_rem, assign_rem, "Modulo assign failed with numerator: {}, divisor: {}", numerator, divisor);
             }
 
 


### PR DESCRIPTION
This PR adds `DivAssign` and `RemAssign` implementations for all StrengthReduced integers, by delegating to the `Div` and `Rem` impls respectively.

This does not add anything you couldn't do before, but it's nice to be able to write:

```rust
var /= divisor
```

instead of

```rust
var = var / divisor
```