### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ description = "Faster integer division and modulus operations"
 
 license = "MIT OR Apache-2.0"
 
-repository = "http://github.com/ejmahler/strength_reduce"
-documentation = "http://docs.rs/strength_reduce"
+repository = "https://github.com/ejmahler/strength_reduce"
+documentation = "https://docs.rs/strength_reduce"
 keywords = ["arithmetic", "strength", "reduction", "division", "modulus"]
 categories = ["algorithms", "data-structures"]
 readme = "README.md"


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97